### PR TITLE
Include enabled extension configuration in templates

### DIFF
--- a/lib/extensions/email_confirmation/README.md
+++ b/lib/extensions/email_confirmation/README.md
@@ -17,11 +17,10 @@ Follow the instructions for extensions in [README.md](../../../README.md#add-ext
 Add the following section to your `WEB_PATH/templates/pow/registration/edit.html.eex` template (you may need to generate the templates first) after the `pow_user_id_field` field:
 
 ```elixir
-<%= if @changeset.data.unconfirmed_email do %>
-  <div>
-    <p>Click the link in the confirmation email to change your email to <%= content_tag(:span, @changeset.data.unconfirmed_email) %>.</p>
-  </div>
-<% end %>
+<p :if={@changeset.data.unconfirmed_email} class="phx-no-feedback:hidden mt-3 flex gap-3 text-sm leading-6 text-rose-600">
+  <.icon name="hero-exclamation-circle-mini" class="mt-0.5 w-5 h-5 flex-none" />
+  Click the link in the confirmation email to change your email to <span class="font-semibold text-brand hover:underline">@changeset.data.unconfirmed_email)</span>.
+</p>
 ```
 
 ## Prevent persistent session sign in

--- a/lib/extensions/persistent_session/README.md
+++ b/lib/extensions/persistent_session/README.md
@@ -23,6 +23,5 @@ end
 By default, the persistent session is automatically used if the extension has been enabled. If you wish to let the user manage this, you should add the following checkbox to the form in `WEB_PATH/templates/pow/session/new.html.eex` (you may need to generate the templates first):
 
 ```elixir
-<%= label f, :persistent_session, "Remember me" %>
-<%= checkbox f, :persistent_session %>
+<.input field={f[:persistent_session]} type="checkbox" label="Keep me logged in" />
 ```

--- a/lib/extensions/reset_password/README.md
+++ b/lib/extensions/reset_password/README.md
@@ -13,5 +13,5 @@ Follow the instructions for extensions in [README.md](../../../README.md#add-ext
 Add the following link to your `WEB_PATH/controllers/pow/session/new.html.heex` template (you may need to generate the templates first):
 
 ```elixir
-link("Reset password", to: ~p"/reset-password")
+<.link navigate={~p"/reset-password/new"} class="text-sm font-semibold">Forgot your password?<./link>
 ```

--- a/lib/extensions/reset_password/phoenix/controllers/reset_password_html.ex
+++ b/lib/extensions/reset_password/phoenix/controllers/reset_password_html.ex
@@ -8,6 +8,12 @@ defmodule PowResetPassword.Phoenix.ResetPasswordHTML do
   <div class="mx-auto max-w-sm">
     <.header class="text-center">
       Reset password
+      <:subtitle>
+        Know your password?
+        <.link navigate={<%= __inline_route__(Pow.Phoenix.SessionController, :new) %>} class="font-semibold text-brand hover:underline">
+          Sign in
+        </.link> now.
+      </:subtitle>
     </.header>
 
     <.simple_form :let={f} for={<%= "@changeset" %>} as={:user} action={<%= "@action" %>} phx-update="ignore">

--- a/lib/pow/phoenix/controllers/registration_html.ex
+++ b/lib/pow/phoenix/controllers/registration_html.ex
@@ -39,6 +39,9 @@ defmodule Pow.Phoenix.RegistrationHTML do
     </.header>
 
     <.simple_form :let={f} for={<%= "@changeset" %>} as={:user} action={<%= "@action" %>} phx-update="ignore">
+      <.error :if={Pow.Plug.extension_enabled?(@conn, PowResetPassword) && @changeset.data.unconfirmed_email}>
+        <span>Click the link in the confirmation email to change your email to <span class="font-semibold"><%%= @changeset.data.unconfirmed_email %></span>.</span>
+      </.error>
       <.error :if={<%= "@changeset.action" %>}>Oops, something went wrong! Please check the errors below.</.error>
       <.input field={<%= "f[:current_password]" %>} type="password" label="Current password" value={nil} required />
       <.input field={<%= "f[\#{__user_id_field__("@changeset", :key)}]" %>} type={<%= __user_id_field__("@changeset", :type) %>} label={<%= __user_id_field__("@changeset", :label) %>} required />

--- a/lib/pow/phoenix/controllers/session_html.ex
+++ b/lib/pow/phoenix/controllers/session_html.ex
@@ -21,6 +21,13 @@ defmodule Pow.Phoenix.SessionHTML do
       <.input field={<%= "f[\#{__user_id_field__("@changeset", :key)}]" %>} type={<%= __user_id_field__("@changeset", :type) %>} label={<%= __user_id_field__("@changeset", :label) %>} required />
       <.input field={<%= "f[:password]" %>} type="password" label="Password" value={nil} required />
 
+      <:actions :let={f} :if={Pow.Plug.extension_enabled?(@conn, PowPersistentSession) || Pow.Plug.extension_enabled?(@conn, PowResetPassword)}>
+        <.input :if={Pow.Plug.extension_enabled?(@conn, PowPersistentSession)} field={f[:persistent_session]} type="checkbox" label="Keep me logged in" />
+        <.link :if={Pow.Plug.extension_enabled?(@conn, PowResetPassword)} href={<%= __inline_route__(PowResetPassword.Phoenix.ResetPasswordController, :new) %>} class="text-sm font-semibold">
+          Forgot your password?
+        </.link>
+      </:actions>
+
       <:actions>
         <.button phx-disable-with="Signing in..." class="w-full">
           Sign in <span aria-hidden="true">→</span>

--- a/lib/pow/plug.ex
+++ b/lib/pow/plug.ex
@@ -265,4 +265,10 @@ defmodule Pow.Plug do
       module           -> {module, []}
     end
   end
+
+  @doc false
+  @spec extension_enabled?(Conn.t(), atom()) :: boolean()
+  def extension_enabled?(conn, extension) do
+    extension in Config.get(fetch_config(conn), :extensions, [])
+  end
 end

--- a/test/pow/plug_test.exs
+++ b/test/pow/plug_test.exs
@@ -152,6 +152,12 @@ defmodule Pow.PlugTest do
     assert Plug.verify_token(conn, "salt", signed_token) == {:ok, "token"}
   end
 
+  test "extension_enabled?/2" do
+    refute Plug.extension_enabled?(conn(@default_config), PowResetPassword)
+    assert Plug.extension_enabled?(conn(@default_config ++ [extensions: [PowResetPassword]]), PowResetPassword)
+    refute Plug.extension_enabled?(conn(@default_config ++ [extensions: [PowResetPassword]]), PowEmailConfirmation)
+  end
+
   defp auth_user_conn() do
     conn        = conn_with_session_plug()
     {:ok, conn} = Plug.authenticate_user(conn, %{"email" => "mock@example.com", "password" => "secret"})


### PR DESCRIPTION
For better usability, the suggested manual extension configuration are now included in the templates. This makes it so you won't have to update anything.