### PR TITLE
Remove route helper usage in tests

### DIFF
--- a/guides/disable_registration.md
+++ b/guides/disable_registration.md
@@ -6,7 +6,7 @@ First you should follow the [Modify templates](../README.md#modify-templates) se
 
 ## Templates
 
-Open up `WEB_PATH/controllers/pow/session_html/new.html.heex` and remove the `Routes.pow_registration_path/2` link. Delete the `WEB_PATH/controllers/pow/registration_html/new.html.heex` file.
+Open up `WEB_PATH/controllers/pow/session_html/new.html.heex` and remove the registration link. Delete the `WEB_PATH/controllers/pow/registration_html/new.html.heex` file.
 
 ## Routes
 

--- a/lib/pow/extension/phoenix/router.ex
+++ b/lib/pow/extension/phoenix/router.ex
@@ -7,7 +7,7 @@ defmodule Pow.Extension.Phoenix.Router do
   Configure `lib/my_project_web/router.ex` the following way:
 
       defmodule MyAppWeb.Router do
-        use Phoenix.Router
+        use MyAppWeb, :router
         use Pow.Phoenix.Router
         use Pow.Extension.Phoenix.Router,
           extensions: [PowExtensionOne, PowExtensionTwo]

--- a/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
+++ b/test/extensions/email_confirmation/phoenix/controllers/confirmation_controller_test.exs
@@ -10,9 +10,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
 
   describe "show/2" do
     test "confirms with valid token", %{conn: conn} do
-      conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("valid")))
+      conn = get(conn, ~p"/confirm-email/#{sign_token("valid")}")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :info) == "The email address has been confirmed."
 
       assert user = Process.get({:user, 1})
@@ -23,9 +23,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
     end
 
     test "confirms with valid token and :unconfirmed_email", %{conn: conn} do
-      conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("valid-with-unconfirmed-changed-email")))
+      conn = get(conn, ~p"/confirm-email/#{sign_token("valid-with-unconfirmed-changed-email")}")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :info) == "The email address has been confirmed."
 
       assert user = Process.get({:user, 1})
@@ -35,27 +35,27 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
     end
 
     test "fails with unique constraint", %{conn: conn} do
-      conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("valid-with-taken-email")))
+      conn = get(conn, ~p"/confirm-email/#{sign_token("valid-with-taken-email")}")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The email address couldn't be confirmed."
 
       refute Process.get({:user, 1})
     end
 
     test "fails with invalid token", %{conn: conn} do
-      conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("invalid")))
+      conn = get(conn, ~p"/confirm-email/#{sign_token("invalid")}")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The confirmation token is invalid or has expired."
 
       refute Process.get({:user, 1})
     end
 
     test "fails with unsigned token", %{conn: conn} do
-      conn = get(conn, Routes.pow_email_confirmation_confirmation_path(conn, :show, "valid"))
+      conn = get(conn, ~p"/confirm-email/#{"valid"}")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The confirmation token is invalid or has expired."
 
       refute Process.get({:user, 1})
@@ -66,9 +66,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       conn       =
         conn
         |> Pow.Plug.assign_current_user(%User{id: 1}, [])
-        |> get(Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("valid")))
+        |> get(~p"/confirm-email/#{sign_token("valid")}")
 
-      assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
+      assert redirected_to(conn) == ~p"/registration/edit"
       assert Pow.Plug.current_user(conn)
       refute conn.private[:plug_session][@session_key] == session_id
     end
@@ -78,9 +78,9 @@ defmodule PowEmailConfirmation.Phoenix.ConfirmationControllerTest do
       conn       =
         conn
         |> Pow.Plug.assign_current_user(%User{id: 2}, [])
-        |> get(Routes.pow_email_confirmation_confirmation_path(conn, :show, sign_token("valid")))
+        |> get(~p"/confirm-email/#{sign_token("valid")}")
 
-      assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
+      assert redirected_to(conn) == ~p"/registration/edit"
       assert Pow.Plug.current_user(conn)
       assert conn.private[:plug_session][@session_key] == session_id
     end

--- a/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
+++ b/test/extensions/invitation/phoenix/controllers/invitation_controller_test.exs
@@ -12,7 +12,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
 
   describe "new/2" do
     test "not signed in", %{conn: conn} do
-      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :new))
+      conn = get(conn, ~p"/invitations/new")
 
       assert_not_authenticated_redirect(conn)
     end
@@ -21,7 +21,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> get(Routes.pow_invitation_invitation_path(conn, :new))
+        |> get(~p"/invitations/new")
 
       assert html = html_response(conn, 200)
 
@@ -40,7 +40,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
         conn
         |> Conn.put_private(:pow_test_config, user: UsernameUser)
         |> Pow.Plug.assign_current_user(@user, [])
-        |> get(Routes.pow_invitation_invitation_path(conn, :new))
+        |> get(~p"/invitations/new")
 
       assert html = html_response(conn, 200)
 
@@ -57,10 +57,10 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
     @valid_params %{"user" => %{"email" => "test@example.com"}}
     @invalid_params %{"user" => %{"email" => "invalid"}}
     @valid_params_email_taken %{"user" => %{"email" => "taken@example.com"}}
-    @valid_params_no_email %{"user" => %{"email" => :no_email}}
+    @valid_params_no_email %{"user" => %{"email" => "no_email"}}
 
     test "not signed in", %{conn: conn} do
-      conn = post(conn, Routes.pow_invitation_invitation_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/invitations", @valid_params)
 
       assert_not_authenticated_redirect(conn)
     end
@@ -69,7 +69,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> post(Routes.pow_invitation_invitation_path(conn, :create, @valid_params))
+        |> post(~p"/invitations", @valid_params)
 
       assert_received {:mail_mock, mail}
 
@@ -79,7 +79,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       assert mail.html =~ "<p>You've been invited by <strong>#{@user.email}</strong>."
       assert mail.html =~ @url_regex
 
-      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :new)
+      assert redirected_to(conn) == ~p"/invitations/new"
       assert get_flash(conn, :info) == "An e-mail with invitation link has been sent."
     end
 
@@ -87,7 +87,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> post(Routes.pow_invitation_invitation_path(conn, :create, @invalid_params))
+        |> post(~p"/invitations", @invalid_params)
 
       assert html = html_response(conn, 200)
 
@@ -103,11 +103,11 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> post(Routes.pow_invitation_invitation_path(conn, :create, @valid_params_email_taken))
+        |> post(~p"/invitations", @valid_params_email_taken)
 
       refute_received {:mail_mock, _mail}
 
-      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :new)
+      assert redirected_to(conn) == ~p"/invitations/new"
       assert get_flash(conn, :info) == "An e-mail with invitation link has been sent."
     end
 
@@ -116,7 +116,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
         conn
         |> Conn.put_private(:pow_prevent_user_enumeration, false)
         |> Pow.Plug.assign_current_user(@user, [])
-        |> post(Routes.pow_invitation_invitation_path(conn, :create, @valid_params_email_taken))
+        |> post(~p"/invitations", @valid_params_email_taken)
 
       assert html = html_response(conn, 200)
 
@@ -132,17 +132,17 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> post(Routes.pow_invitation_invitation_path(conn, :create, @valid_params_no_email))
+        |> post(~p"/invitations", @valid_params_no_email)
 
       refute_received {:mail_mock, _mail}
 
-      assert redirected_to(conn) == Routes.pow_invitation_invitation_path(conn, :show, sign_token("valid"))
+      assert redirected_to(conn) == ~p"/invitations/#{sign_token("valid")}"
     end
   end
 
   describe "show/2" do
     test "not signed in", %{conn: conn} do
-      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :show, sign_token("valid")))
+      conn = get(conn, ~p"/invitations/#{sign_token("valid")}")
 
       assert_not_authenticated_redirect(conn)
     end
@@ -151,7 +151,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> get(Routes.pow_invitation_invitation_path(conn, :show, sign_token("valid")))
+        |> get(~p"/invitations/#{sign_token("valid")}")
 
       assert html = html_response(conn, 200)
       assert html =~ @url_regex
@@ -163,27 +163,27 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> get(Routes.pow_invitation_invitation_path(conn, :edit, sign_token("valid")))
+        |> get(~p"/invitations/#{sign_token("valid")}/edit")
 
       assert_authenticated_redirect(conn)
     end
 
     test "with invalid invitation token", %{conn: conn} do
-      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :edit, sign_token("invalid")))
+      conn = get(conn, ~p"/invitations/#{sign_token("invalid")}/edit")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The invitation doesn't exist."
     end
 
     test "with unsigned invitation token", %{conn: conn} do
-      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :edit, "valid"))
+      conn = get(conn, ~p"/invitations/#{"valid"}/edit")
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The invitation doesn't exist."
     end
 
     test "shows", %{conn: conn} do
-      conn = get(conn, Routes.pow_invitation_invitation_path(conn, :edit, sign_token("valid")))
+      conn = get(conn, ~p"/invitations/#{sign_token("valid")}/edit")
 
       assert Conn.get_resp_header(conn, "cache-control") == ["no-cache, no-store, must-revalidate"]
 
@@ -221,27 +221,27 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
       conn =
         conn
         |> Pow.Plug.assign_current_user(@user, [])
-        |> put(Routes.pow_invitation_invitation_path(conn, :update, sign_token("valid"), @valid_params))
+        |> put(~p"/invitations/#{sign_token("valid")}", @valid_params)
 
       assert_authenticated_redirect(conn)
     end
 
     test "with invalid invitation", %{conn: conn} do
-      conn = put(conn, Routes.pow_invitation_invitation_path(conn, :update, sign_token("invalid"), @valid_params))
+      conn = put(conn, ~p"/invitations/#{sign_token("invalid")}", @valid_params)
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The invitation doesn't exist."
     end
 
     test "with unsigned invitation token", %{conn: conn} do
-      conn = put(conn, Routes.pow_invitation_invitation_path(conn, :update, "valid", @valid_params))
+      conn = put(conn, ~p"/invitations/#{"valid"}", @valid_params)
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :error) == "The invitation doesn't exist."
     end
 
     test "with valid params", %{conn: conn} do
-      conn = put(conn, Routes.pow_invitation_invitation_path(conn, :update, sign_token("valid"), @valid_params))
+      conn = put(conn, ~p"/invitations/#{sign_token("valid")}", @valid_params)
 
       assert redirected_to(conn) == "/after_registration"
       assert get_flash(conn, :info) == "user_created"
@@ -249,7 +249,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
     end
 
     test "with valid params and email taken", %{conn: conn} do
-      conn = put(conn, Routes.pow_invitation_invitation_path(conn, :update, sign_token("valid"), @valid_params_email_taken))
+      conn = put(conn, ~p"/invitations/#{sign_token("valid")}", @valid_params_email_taken)
 
       assert html = html_response(conn, 200)
 
@@ -262,7 +262,7 @@ defmodule PowInvitation.Phoenix.InvitationControllerTest do
     end
 
     test "with invalid params", %{conn: conn} do
-      conn = put(conn, Routes.pow_invitation_invitation_path(conn, :update, sign_token("valid"), @invalid_params))
+      conn = put(conn, ~p"/invitations/#{sign_token("valid")}", @invalid_params)
 
       assert html = html_response(conn, 200)
 

--- a/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
+++ b/test/extensions/persistent_session/phoenix/controllers/controller_callbacks_test.exs
@@ -12,7 +12,7 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
   describe "Pow.Phoenix.SessionController.create/2" do
     test "generates cookie", %{conn: conn} do
       expected_user = RepoMock.get_by(User, [email: "test@example.com"], [])
-      conn          = post(conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params}))
+      conn          = post(conn, ~p"/session", %{"user" => @valid_params})
 
       assert session_fingerprint = conn.private[:pow_session_metadata][:fingerprint]
       assert %{max_age: @max_age, path: "/", value: id} = conn.resp_cookies[@cookie_key]
@@ -20,15 +20,15 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
     end
 
     test "with persistent_session param set to false", %{conn: conn} do
-      params = %{"user" => Map.put(@valid_params, "persistent_session", false)}
-      conn   = post(conn, Routes.pow_session_path(conn, :create, params))
+      params = %{"user" => Map.put(@valid_params, "persistent_session", "false")}
+      conn   = post(conn, ~p"/session", params)
 
       refute conn.resp_cookies[@cookie_key]
     end
 
     test "with persistent_session param set to true", %{conn: conn} do
-      params = %{"user" => Map.put(@valid_params, "persistent_session", true)}
-      conn   = post(conn, Routes.pow_session_path(conn, :create, params))
+      params = %{"user" => Map.put(@valid_params, "persistent_session", "true")}
+      conn   = post(conn, ~p"/session", params)
 
       assert conn.resp_cookies[@cookie_key]
     end
@@ -36,11 +36,11 @@ defmodule PowPersistentSession.Phoenix.ControllerCallbacksTest do
 
   describe "Pow.Phoenix.SessionController.delete/2" do
     test "expires cookie", %{conn: conn} do
-      conn = post(conn, Routes.pow_session_path(conn, :create, %{"user" => @valid_params}))
+      conn = post(conn, ~p"/session", %{"user" => @valid_params})
 
       assert %{value: id} = conn.resp_cookies[@cookie_key]
 
-      conn = delete(conn, Routes.pow_session_path(conn, :delete))
+      conn = delete(conn, ~p"/session")
 
       assert conn.resp_cookies[@cookie_key] == %{max_age: 0, path: "/", universal_time: {{1970, 1, 1}, {0, 0, 0}}}
       assert get_from_cache(conn, id) == :not_found

--- a/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
+++ b/test/extensions/reset_password/phoenix/controllers/reset_password_controller_test.exs
@@ -12,7 +12,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
 
   describe "new/2" do
     test "shows", %{conn: conn} do
-      conn = get(conn, Routes.pow_reset_password_reset_password_path(conn, :new))
+      conn = get(conn, ~p"/reset-password/new")
 
       assert html = html_response(conn, 200)
 
@@ -30,7 +30,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       conn =
         conn
         |> PowPlug.assign_current_user(@user, [])
-        |> get(Routes.pow_reset_password_reset_password_path(conn, :new))
+        |> get(~p"/reset-password/new")
 
       assert_authenticated_redirect(conn)
     end
@@ -44,13 +44,13 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       conn =
         conn
         |> PowPlug.assign_current_user(@user, [])
-        |> get(Routes.pow_reset_password_reset_password_path(conn, :new))
+        |> get(~p"/reset-password/new")
 
       assert_authenticated_redirect(conn)
     end
 
     test "with valid params", %{conn: conn, ets: ets} do
-      conn           = post(conn, Routes.pow_reset_password_reset_password_path(conn, :create, @valid_params))
+      conn           = post(conn, ~p"/reset-password", @valid_params)
       [{[token], _}] = ResetTokenCache.all([backend: ets], [:_])
 
       assert_received {:mail_mock, mail}
@@ -59,14 +59,14 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       assert mail.text =~ "\nhttp://localhost/reset-password/#{sign_token(conn, token)}\n"
       assert mail.html =~ "<a href=\"http://localhost/reset-password/#{sign_token(conn, token)}\">"
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :info) == "If an account for the provided email exists, an email with reset instructions will be sent to you. Please check your inbox."
     end
 
     test "with invalid params", %{conn: conn} do
-      conn = post(conn, Routes.pow_reset_password_reset_password_path(conn, :create, @invalid_params))
+      conn = post(conn, ~p"/reset-password", @invalid_params)
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :info) == "If an account for the provided email exists, an email with reset instructions will be sent to you. Please check your inbox."
     end
 
@@ -74,7 +74,7 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       conn =
         conn
         |> Conn.put_private(:pow_prevent_user_enumeration, false)
-        |> post(Routes.pow_reset_password_reset_password_path(conn, :create, @invalid_params))
+        |> post(~p"/reset-password", @invalid_params)
 
       assert html = html_response(conn, 200)
       assert get_flash(conn, :error) == "No account exists for the provided email. Please try again."
@@ -97,28 +97,28 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       conn =
         conn
         |> PowPlug.assign_current_user(@user, [])
-        |> get(Routes.pow_reset_password_reset_password_path(conn, :edit, token))
+        |> get(~p"/reset-password/#{token}")
 
       assert_authenticated_redirect(conn)
     end
 
     test "with invalid token", %{conn: conn} do
-      conn = get(conn, Routes.pow_reset_password_reset_password_path(conn, :edit, "invalid"))
+      conn = get(conn, ~p"/reset-password/invalid")
 
-      assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
+      assert redirected_to(conn) == ~p"/reset-password/new"
       assert get_flash(conn, :error) == "The reset token has expired."
     end
 
     test "with unsigned token", %{conn: conn, token: token} do
       token = decode_token(conn, token)
-      conn  = get(conn, Routes.pow_reset_password_reset_password_path(conn, :edit, token))
+      conn  = get(conn, ~p"/reset-password/#{token}")
 
-      assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
+      assert redirected_to(conn) == ~p"/reset-password/new"
       assert get_flash(conn, :error) == "The reset token has expired."
     end
 
     test "valid token", %{conn: conn, token: token} do
-      conn = get(conn, Routes.pow_reset_password_reset_password_path(conn, :edit, token))
+      conn = get(conn, ~p"/reset-password/#{token}")
 
       assert html = html_response(conn, 200)
 
@@ -154,37 +154,37 @@ defmodule PowResetPassword.Phoenix.ResetPasswordControllerTest do
       conn =
         conn
         |> PowPlug.assign_current_user(@user, [])
-        |> put(Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params))
+        |> put(~p"/reset-password/#{token}", @valid_params)
 
       assert_authenticated_redirect(conn)
     end
 
     test "with invalid token", %{conn: conn} do
-      conn = put(conn, Routes.pow_reset_password_reset_password_path(conn, :update, "invalid", @valid_params))
+      conn = put(conn, ~p"/reset-password/invalid", @valid_params)
 
-      assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
+      assert redirected_to(conn) == ~p"/reset-password/new"
       assert get_flash(conn, :error) == "The reset token has expired."
     end
 
     test "with unsigned token", %{conn: conn, token: token} do
       token = decode_token(conn, token)
-      conn  = put(conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params))
+      conn  = put(conn, ~p"/reset-password/#{token}", @valid_params)
 
-      assert redirected_to(conn) == Routes.pow_reset_password_reset_password_path(conn, :new)
+      assert redirected_to(conn) == ~p"/reset-password/new"
       assert get_flash(conn, :error) == "The reset token has expired."
     end
 
     test "with valid params", %{conn: conn, token: token} do
-      conn = put(conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @valid_params))
+      conn = put(conn, ~p"/reset-password/#{token}", @valid_params)
 
-      assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
+      assert redirected_to(conn) == ~p"/session/new"
       assert get_flash(conn, :info) == "The password has been updated."
 
       assert {:error, _conn} = Plug.load_user_by_token(conn, token)
     end
 
     test "with invalid params", %{conn: conn, token: token} do
-      conn = put(conn, Routes.pow_reset_password_reset_password_path(conn, :update, token, @invalid_params))
+      conn = put(conn, ~p"/reset-password/#{token}", @invalid_params)
 
       assert html = html_response(conn, 200)
 

--- a/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
+++ b/test/mix/tasks/extension/phoenix/pow.extension.phoenix.mailer.gen.templates_test.exs
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Pow.Extension.Phoenix.Mailer.Gen.TemplatesTest do
 
           def router do
             quote do
-              use Phoenix.Router
+              use Phoenix.Router, helpers: false
             end
           end
 

--- a/test/pow/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow/phoenix/controllers/registration_controller_test.exs
@@ -7,12 +7,12 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
 
   describe "new/2" do
     test "shows", %{conn: conn} do
-      conn = get(conn, Routes.pow_registration_path(conn, :new))
+      conn = get(conn, ~p"/registration/new")
 
       assert Conn.get_resp_header(conn, "cache-control") == ["no-cache, no-store, must-revalidate"]
 
       assert html = html_response(conn, 200)
-      assert html =~ Routes.pow_registration_path(conn, :create)
+      assert html =~ ~p"/registration"
 
       html_tree = DOM.parse(html)
 
@@ -41,7 +41,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn =
         conn
         |> Plug.assign_current_user(%{id: 1}, [])
-        |> get(Routes.pow_registration_path(conn, :new))
+        |> get(~p"/registration/new")
 
       assert_authenticated_redirect(conn)
     end
@@ -50,7 +50,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn =
         conn
         |> Conn.put_private(:pow_test_config, :username_user)
-        |> get(Routes.pow_registration_path(conn, :new))
+        |> get(~p"/registration/new")
 
       assert html = html_response(conn, 200)
 
@@ -71,13 +71,13 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn =
         conn
         |> Plug.assign_current_user(%{id: 1}, [])
-        |> post(Routes.pow_registration_path(conn, :create, @valid_params))
+        |> post(~p"/registration", @valid_params)
 
       assert_authenticated_redirect(conn)
     end
 
     test "with valid params", %{conn: conn} do
-      conn = post(conn, Routes.pow_registration_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/registration", @valid_params)
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) == "user_created"
@@ -86,7 +86,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     end
 
     test "with invalid params", %{conn: conn} do
-      conn = post(conn, Routes.pow_registration_path(conn, :create, @invalid_params))
+      conn = post(conn, ~p"/registration", @invalid_params)
 
       assert html = html_response(conn, 200)
 
@@ -112,7 +112,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn =
         conn
         |> create_user_and_sign_in()
-        |> get(Routes.pow_registration_path(conn, :edit))
+        |> get(~p"/registration/edit")
 
       assert html = html_response(conn, 200)
 
@@ -151,7 +151,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
         conn
         |> Conn.put_private(:pow_test_config, :username_user)
         |> create_user_and_sign_in()
-        |> get(Routes.pow_registration_path(conn, :edit))
+        |> get(~p"/registration/edit")
 
       assert html = html_response(conn, 200)
 
@@ -165,7 +165,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     end
 
     test "not signed in", %{conn: conn} do
-      conn = get(conn, Routes.pow_registration_path(conn, :edit))
+      conn = get(conn, ~p"/registration/edit")
 
       assert_not_authenticated_redirect(conn)
     end
@@ -176,7 +176,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
     @invalid_params %{"user" => %{"email" => "invalid@example.com", "password" => "invalid"}}
 
     test "not signed in", %{conn: conn} do
-      conn = put(conn, Routes.pow_registration_path(conn, :update, @valid_params))
+      conn = put(conn, ~p"/registration", @valid_params)
 
       assert_not_authenticated_redirect(conn)
     end
@@ -185,9 +185,9 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn = create_user_and_sign_in(conn)
       session_id = conn.private[:plug_session]["auth"]
 
-      conn = put(conn, Routes.pow_registration_path(conn, :update, @valid_params))
+      conn = put(conn, ~p"/registration", @valid_params)
 
-      assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
+      assert redirected_to(conn) == ~p"/registration/edit"
       assert get_flash(conn, :info) == "Your account has been updated."
       assert user = Plug.current_user(conn)
       assert user.id == :updated
@@ -198,7 +198,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn = create_user_and_sign_in(conn)
       session_id = conn.private[:plug_session]["auth"]
 
-      conn = put(conn, Routes.pow_registration_path(conn, :update, @invalid_params))
+      conn = put(conn, ~p"/registration", @invalid_params)
 
       assert html = html_response(conn, 200)
 
@@ -224,7 +224,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
 
   describe "delete/2" do
     test "not signed in", %{conn: conn} do
-      conn = delete(conn, Routes.pow_registration_path(conn, :delete))
+      conn = delete(conn, ~p"/registration")
 
       assert_not_authenticated_redirect(conn)
     end
@@ -233,7 +233,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn =
         conn
         |> create_user_and_sign_in()
-        |> delete(Routes.pow_registration_path(conn, :delete))
+        |> delete(~p"/registration")
 
       assert redirected_to(conn) == "/signed_out"
       assert get_flash(conn, :info) == "Your account has been deleted. Sorry to see you go!"
@@ -245,9 +245,9 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
       conn =
         conn
         |> Plug.assign_current_user(:fail_deletion, [])
-        |> delete(Routes.pow_registration_path(conn, :delete))
+        |> delete(~p"/registration")
 
-      assert redirected_to(conn) == Routes.pow_registration_path(conn, :edit)
+      assert redirected_to(conn) == ~p"/registration/edit"
       assert get_flash(conn, :error) == "Your account could not be deleted."
       assert Plug.current_user(conn) == :fail_deletion
     end
@@ -256,7 +256,7 @@ defmodule Pow.Phoenix.RegistrationControllerTest do
   @params %{"user" => %{"email" => "mock@example.com"}}
 
   defp create_user_and_sign_in(conn) do
-    conn = post(conn, Routes.pow_registration_path(conn, :create, @params))
+    conn = post(conn, ~p"/registration", @params)
 
     assert %{id: 1} = Plug.current_user(conn)
     assert conn.private[:plug_session]["auth"]

--- a/test/pow/phoenix/controllers/session_controller_test.exs
+++ b/test/pow/phoenix/controllers/session_controller_test.exs
@@ -10,18 +10,18 @@ defmodule Pow.Phoenix.SessionControllerTest do
       conn =
         conn
         |> Plug.assign_current_user(%{id: 1}, [])
-        |> get(Routes.pow_session_path(conn, :new))
+        |> get(~p"/session/new")
 
       assert_authenticated_redirect(conn)
     end
 
     test "shows", %{conn: conn} do
-      conn = get(conn, Routes.pow_session_path(conn, :new))
+      conn = get(conn, ~p"/session/new")
 
       assert Conn.get_resp_header(conn, "cache-control") == ["no-cache, no-store, must-revalidate"]
 
       assert html = html_response(conn, 200)
-      assert html =~ Routes.pow_session_path(conn, :create)
+      assert html =~ ~p"/session"
       refute html =~ "request_path="
 
       html_tree = DOM.parse(html)
@@ -44,17 +44,17 @@ defmodule Pow.Phoenix.SessionControllerTest do
     end
 
     test "with request_path", %{conn: conn} do
-      conn = get(conn, Routes.pow_session_path(conn, :new, request_path: "/example"))
+      conn = get(conn, ~p"/session/new?#{[request_path: "/example"]}")
 
       assert html = html_response(conn, 200)
-      assert html =~ Routes.pow_session_path(conn, :create, request_path: "/example")
+      assert html =~ ~p"/session?#{[request_path: "/example"]}"
     end
 
     test "shows with username user", %{conn: conn} do
       conn =
         conn
         |> Conn.put_private(:pow_test_config, :username_user)
-        |> get(Routes.pow_session_path(conn, :new))
+        |> get(~p"/session/new")
 
       assert html = html_response(conn, 200)
 
@@ -75,13 +75,13 @@ defmodule Pow.Phoenix.SessionControllerTest do
       conn =
         conn
         |> Plug.assign_current_user(%{id: 1}, [])
-        |> post(Routes.pow_session_path(conn, :create, @valid_params))
+        |> post(~p"/session", @valid_params)
 
       assert_authenticated_redirect(conn)
     end
 
     test "with valid params", %{conn: conn} do
-      conn = post(conn, Routes.pow_session_path(conn, :create, @valid_params))
+      conn = post(conn, ~p"/session", @valid_params)
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) == "signed_in"
@@ -90,7 +90,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
     end
 
     test "with invalid params", %{conn: conn} do
-      conn = post(conn, Routes.pow_session_path(conn, :create, @invalid_params))
+      conn = post(conn, ~p"/session", @invalid_params)
 
       assert html = html_response(conn, 200)
       assert get_flash(conn, :error) == "The provided login details did not work. Please verify your credentials, and try again."
@@ -109,7 +109,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
     end
 
     test "with valid params and request_path", %{conn: conn} do
-      conn = post(conn, Routes.pow_session_path(conn, :create, Map.put(@valid_params, "request_path", "/custom-url")))
+      conn = post(conn, ~p"/session", Map.put(@valid_params, "request_path", "/custom-url"))
 
       assert redirected_to(conn) == "/custom-url"
       assert get_flash(conn, :info) == "signed_in"
@@ -118,7 +118,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
     end
 
     test "with invalid params and request_path", %{conn: conn} do
-      conn = post(conn, Routes.pow_session_path(conn, :create, Map.put(@invalid_params, "request_path", "/custom-url")))
+      conn = post(conn, ~p"/session", Map.put(@invalid_params, "request_path", "/custom-url"))
 
       assert html = html_response(conn, 200)
       assert get_flash(conn, :error) == "The provided login details did not work. Please verify your credentials, and try again."
@@ -128,7 +128,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
 
   describe "delete/2" do
     test "not signed in", %{conn: conn} do
-      conn = delete(conn, Routes.pow_session_path(conn, :delete))
+      conn = delete(conn, ~p"/session")
 
       assert_not_authenticated_redirect(conn)
     end
@@ -136,7 +136,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
     test "removes authenticated", %{conn: conn} do
       conn = authenticated_conn(conn)
 
-      conn = delete(conn, Routes.pow_session_path(conn, :delete))
+      conn = delete(conn, ~p"/session")
       assert redirected_to(conn) == "/signed_out"
       assert get_flash(conn, :info) == "signed_out"
       refute Plug.current_user(conn)
@@ -147,7 +147,7 @@ defmodule Pow.Phoenix.SessionControllerTest do
   @auth_params %{"user" => %{"email" => "mock@example.com", "password" => "secret"}}
 
   defp authenticated_conn(conn) do
-    conn = post(conn, Routes.pow_session_path(conn, :create, @auth_params))
+    conn = post(conn, ~p"/session", @auth_params)
 
     assert %{id: 1} = Plug.current_user(conn)
     assert conn.private[:plug_session]["auth"]

--- a/test/support/extensions/mocks.ex
+++ b/test/support/extensions/mocks.ex
@@ -88,7 +88,7 @@ defmodule Pow.Test.ExtensionMocks do
   def __phoenix_endpoint__(web_module, config, opts) do
     module = Module.concat([web_module, Phoenix.Router])
     quoted = quote do
-      use Phoenix.Router
+      use Phoenix.Router, helpers: false
       use Pow.Phoenix.Router
       use Pow.Extension.Phoenix.Router, unquote(config)
 
@@ -169,9 +169,12 @@ defmodule Pow.Test.ExtensionMocks do
           import Pow.Test.Phoenix.ConnCase, only: [get_flash: 2]
           import ControllerAssertions
 
-          alias Router.Helpers, as: Routes
-
           @endpoint Endpoint
+
+          use Phoenix.VerifiedRoutes,
+            endpoint: Endpoint,
+            router: Router,
+            statics: ~w()
         end
       end
 

--- a/test/support/phoenix/conn_case.ex
+++ b/test/support/phoenix/conn_case.ex
@@ -3,7 +3,7 @@ defmodule Pow.Test.Phoenix.ConnCase do
   use ExUnit.CaseTemplate
 
   alias Pow.Test.EtsCacheMock
-  alias Pow.Test.Phoenix.{ControllerAssertions, Endpoint, Router}
+  alias Pow.Test.Phoenix.{ControllerAssertions, Endpoint, Web}
 
   using do
     quote do
@@ -12,9 +12,9 @@ defmodule Pow.Test.Phoenix.ConnCase do
       import unquote(__MODULE__), only: [get_flash: 2]
       import ControllerAssertions
 
-      alias Router.Helpers, as: Routes
-
       @endpoint Endpoint
+
+      use Web, :verified_routes
     end
   end
 

--- a/test/support/phoenix/controller_assertions.ex
+++ b/test/support/phoenix/controller_assertions.ex
@@ -18,12 +18,10 @@ defmodule Pow.Test.Phoenix.ControllerAssertions do
   @spec assert_not_authenticated_redirect(Plug.Conn.t()) :: Macro.t()
   defmacro assert_not_authenticated_redirect(conn) do
     quote bind_quoted: [conn: conn] do
-      router = Module.concat([conn.private.phoenix_router, Helpers])
-
       expected_path =
         case conn.method do
-          "GET" -> router.pow_session_path(conn, :new, request_path: Phoenix.Controller.current_path(conn))
-          _any  -> router.pow_session_path(conn, :new)
+          "GET" -> ~p"/session/new?#{[request_path: Phoenix.Controller.current_path(conn)]}"
+          _any  -> ~p"/session/new"
         end
 
       assert redirected_to(conn) == expected_path

--- a/test/support/phoenix/router.ex
+++ b/test/support/phoenix/router.ex
@@ -1,6 +1,6 @@
 defmodule Pow.Test.Phoenix.Router do
   @moduledoc false
-  use Phoenix.Router
+  use Pow.Test.Phoenix.Web, :router
   use Pow.Phoenix.Router
 
   pipeline :browser do

--- a/test/support/phoenix/web.ex
+++ b/test/support/phoenix/web.ex
@@ -1,6 +1,26 @@
 defmodule Pow.Test.Phoenix.Web do
   @moduledoc false
 
+  def router do
+    quote do
+      use Phoenix.Router, helpers: false
+
+      # Import common connection and controller functions to use in pipelines
+      import Plug.Conn
+      import Phoenix.Controller
+      import Phoenix.LiveView.Router
+    end
+  end
+
+  def verified_routes do
+    quote do
+      use Phoenix.VerifiedRoutes,
+        endpoint: Pow.Test.Phoenix.Endpoint,
+        router: Pow.Test.Phoenix.Router,
+        statics: ~w()
+    end
+  end
+
   def mail do
     quote do
       use Pow.Phoenix.Mailer.Component


### PR DESCRIPTION
This eliminates all route helper usage in the tests for Pow.