### PR TITLE
Fix Markdown formatting so README properly renders on hexdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Generate the template files:
 mix pow.extension.phoenix.mailer.gen.templates --extension PowResetPassword --extension PowEmailConfirmation
 ```
 
-This will generate template files in the `WEB_PATH/mails/` directory. This will also add the necessary ` mail/0` macro to `WEB_PATH/my_app_web.ex` and update the pow config with ``web_mailer_module: MyAppWeb`.
+This will generate template files in the `WEB_PATH/mails/` directory. This will also add the necessary `mail/0` macro to `WEB_PATH/my_app_web.ex` and update the pow config with `web_mailer_module: MyAppWeb`.
 
 ## Configuration
 


### PR DESCRIPTION
An extra backtick before \`web_mailer_module: MyAppWeb\` causes the [README on hexdocs
](https://hexdocs.pm/pow/README.html) to render everything after it into a giant block of text:

![image](https://user-images.githubusercontent.com/51379939/228717414-d52d54a1-6bdb-4943-af24-babf6d5ef533.png)

The commit removes that backtick so the README should properly render with this change.