### PR TITLE
Issue 707

### DIFF
--- a/lib/pow/ecto/schema/password.ex
+++ b/lib/pow/ecto/schema/password.ex
@@ -99,5 +99,5 @@ defmodule Pow.Ecto.Schema.Password do
 
   @spec raise_not_valid_password_hash!() :: no_return()
   defp raise_not_valid_password_hash!,
-    do: raise ArgumentError, "not a valid encoded password hash"
+  do: raise(ArgumentError, "not a valid encoded password hash")
 end

--- a/lib/pow/ecto/schema/password.ex
+++ b/lib/pow/ecto/schema/password.ex
@@ -99,5 +99,5 @@ defmodule Pow.Ecto.Schema.Password do
 
   @spec raise_not_valid_password_hash!() :: no_return()
   defp raise_not_valid_password_hash!,
-  do: raise(ArgumentError, "not a valid encoded password hash")
+    do: raise(ArgumentError, "not a valid encoded password hash")
 end

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -234,5 +234,5 @@ defmodule Pow.Extension.Ecto.Schema do
 
   @spec raise_missing_field_error!(module(), atom(), atom()) :: no_return()
   defp raise_missing_field_error!(module, field, extension),
-    do: raise SchemaError, message: "A `#{inspect field}` schema field should be defined in #{inspect module} to use #{inspect extension}"
+    do: raise(SchemaError, message: "A `#{inspect field}` schema field should be defined in #{inspect module} to use #{inspect extension}")
 end

--- a/lib/pow/phoenix/template.ex
+++ b/lib/pow/phoenix/template.ex
@@ -115,7 +115,7 @@ defmodule Pow.Phoenix.Template do
       EEx.eval_string(
         content,
         [],
-        functions: import_functions,
+        imports: import_functions,
         file: __CALLER__.file,
         line: __CALLER__.line + 1,
         caller: __CALLER__)

--- a/lib/pow/plug/message_verifier.ex
+++ b/lib/pow/plug/message_verifier.ex
@@ -46,9 +46,9 @@ defmodule Pow.Plug.MessageVerifier do
   end
 
   defp validate_secret_key_base(nil),
-    do: raise ArgumentError, "No conn.secret_key_base set"
+    do: raise(ArgumentError, "No conn.secret_key_base set")
   defp validate_secret_key_base(secret_key_base) when byte_size(secret_key_base) < 64,
-    do: raise ArgumentError, "conn.secret_key_base has to be at least 64 bytes"
+    do: raise(ArgumentError, "conn.secret_key_base has to be at least 64 bytes")
   defp validate_secret_key_base(secret_key_base), do: secret_key_base
 
   defp key_opts(config), do: Keyword.get(config, :key_generator_opts, [])

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -461,14 +461,14 @@ defmodule Pow.Store.Backend.MnesiaCache do
 
           # TODO: Remove by 1.1.0
           {@mnesia_cache_tab, key, {_key, _value, _config, expire}}, invalidators when is_binary(key) and is_number(expire) ->
-            Logger.warn("Deleting old record in the mnesia cache: #{inspect key}")
+            Logger.warning("Deleting old record in the mnesia cache: #{inspect key}")
 
             :mnesia.delete({@mnesia_cache_tab, key})
 
             invalidators
 
           {@mnesia_cache_tab, key, _value}, invalidators ->
-            Logger.warn("Found an unexpected record in the mnesia cache, please delete it: #{inspect key}")
+            Logger.warning("Found an unexpected record in the mnesia cache, please delete it: #{inspect key}")
 
             invalidators
         end,

--- a/lib/pow/store/backend/mnesia_cache/unsplit.ex
+++ b/lib/pow/store/backend/mnesia_cache/unsplit.ex
@@ -165,7 +165,7 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
   end
 
   defp reset_node(node, _config) do
-    Logger.warn("Resetting mnesia on #{inspect node()} and restarting the mnesia cache to connect to #{inspect node}")
+    Logger.warning("Resetting mnesia on #{inspect node()} and restarting the mnesia cache to connect to #{inspect node}")
 
     :mnesia.stop()
     :mnesia.delete_schema([node()])
@@ -183,7 +183,7 @@ defmodule Pow.Store.Backend.MnesiaCache.Unsplit do
         :ok
 
       false ->
-        Logger.warn("Detected a netsplit in the mnesia cluster with node #{inspect node}")
+        Logger.warning("Detected a netsplit in the mnesia cluster with node #{inspect node}")
 
         heal(node, config)
     end


### PR DESCRIPTION
Suggested fixes to deprecation warnings produced by Elixir V1.15.2

In Elixir, using the "raise ..." syntax is widely accepted. However, by switching to the "raise(...)" format, we can clear out multiple verbose "ambiguity" compiler warnings. Any warnings from the pow library have the potential to obscure real issues within a user's code-base. To offer a more streamlined and user-friendly experience, I've chosen to heed the compiler's advice and depart from conventional practices.