### PR TITLE
Fix phoenix view namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.33 (TBA)
+
+## Bug fixes
+
+- [`Pow.Phoenix.Controller`] Fixed regression bug with `Phoenix.View` and `:namespace` option
+- [`Pow.Phoenix.ViewHelpers`] Now falls back to view named modules to prevent upgrade issues
+
 ## v1.0.32 (2023-08-30)
 
 Removed deprecation warnings for Elixir 1.15.

--- a/lib/pow/phoenix/controllers/controller.ex
+++ b/lib/pow/phoenix/controllers/controller.ex
@@ -34,14 +34,16 @@ defmodule Pow.Phoenix.Controller do
   defmacro __using__(config) do
     quote do
       use Phoenix.Controller, (
-        # TODO: Remove when Phoenix 1.7 is required
-        if Code.ensure_loaded?(Phoenix.View) do
-          [namespace: Pow.Phoenix]
-        else
+        # Credo will complain about unless statement but we want this first
+        # credo:disable-for-next-line
+        unless Pow.dependency_vsn_match?(:phoenix, "< 1.7.0") do
           [
             layouts: [html: Pow.Phoenix.Layouts],
             formats: [:html]
           ]
+        else
+          # TODO: Remove when Phoenix 1.7 is required
+          [namespace: Pow.Phoenix]
         end)
 
       import unquote(__MODULE__), only: [require_authenticated: 2, require_not_authenticated: 2, put_no_cache_header: 2]

--- a/lib/pow/phoenix/controllers/view_helpers.ex
+++ b/lib/pow/phoenix/controllers/view_helpers.ex
@@ -102,8 +102,20 @@ defmodule Pow.Phoenix.ViewHelpers do
   def build_view_module(default_view, nil), do: default_view
   def build_view_module(default_view, web_module) when is_atom(web_module) do
     [base, view] = split_default_view(default_view)
+    module = Module.concat([web_module, base, view])
 
-    Module.concat([web_module, base, view])
+    case Code.ensure_loaded?(Phoenix.View) and not Code.ensure_loaded?(module) do
+      # TODO: Remove when Phoenix 1.7 is required
+      true ->
+        module
+        |> to_string()
+        |> Phoenix.Naming.unsuffix("HTML")
+        |> Kernel.<>("View")
+        |> String.to_atom()
+
+      false ->
+        module
+    end
   end
 
   # TODO: Remove `Pow.Phoenix.LayoutView` guard when Phoenix 1.7 is required


### PR DESCRIPTION
#709 introduced a regression bug. This PR solves the issue better by just having fallback logic to find the correctly named module.