### PR TITLE
Fix bug with expired cached keys not invalidated on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.34 (TBA)
+
+**Note:** This release contains an important security fix. It is recommended to update  immediately if you are using the `Pow.Store.Backend.MnesiaCache`.
+
+## Bug fixes
+
+- [`Pow.Store.Backend.MnesiaCache`] Fixed bug where expired cached keys are not invalidated on startup
+
 ## v1.0.33 (2023-09-05)
 
 ## Bug fixes

--- a/lib/pow/store/backend/mnesia_cache.ex
+++ b/lib/pow/store/backend/mnesia_cache.ex
@@ -454,10 +454,9 @@ defmodule Pow.Store.Backend.MnesiaCache do
         :mnesia.foldl(fn
           {@mnesia_cache_tab, key, {_value, expire}}, invalidators when is_list(key) ->
             ttl = Enum.max([expire - timestamp(), 0])
-
-            key
-            |> unwrap()
-            |> append_invalidator(invalidators, ttl, config)
+            [namespace | key] = key
+            config = Config.put(config, :namespace, namespace)
+            append_invalidator(key, invalidators, ttl, config)
 
           # TODO: Remove by 1.1.0
           {@mnesia_cache_tab, key, {_key, _value, _config, expire}}, invalidators when is_binary(key) and is_number(expire) ->


### PR DESCRIPTION
Resolves #713.

The tests didn't catch this because of a commingling of lower and higher lavel cache configs.