### PR TITLE
Update mail layout deprecation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Removed deprecation warnings for Elixir 1.15.
 
 This version is updated to work with Phoenix 1.7, in particular using the new template components structure. All views have been removed, and Pow no longer requires the `phoenix_view` dependency.
 
+Instead of `pow_mailer_layout: {MyAppWeb.LayoutView, :email})` you should use `pow_mailer_layouts: [html: {MyAppWeb.Layouts, :email}, text: {MyAppWeb.Layouts, :email_text}]` in `conn.private`.
+
 Now requires Elixir 1.12+.
 
 ### Enhancements

--- a/lib/pow/phoenix/mailer/mail.ex
+++ b/lib/pow/phoenix/mailer/mail.ex
@@ -61,7 +61,7 @@ defmodule Pow.Phoenix.Mailer.Mail do
   defp handle_deprecated_layout(conn) do
     case Map.has_key?(conn.private, :pow_mailer_layout) do
       true ->
-        IO.warn("`:pow_mailer_layout` in conn.private has been deprecated, please change it to `:pow_mailer_layouts`")
+        IO.warn("`pow_mailer_layout: #{inspect conn.private[:pow_mailer_layout]}` in conn.private has been deprecated, please change it to `pow_mailer_layouts: [_: #{inspect conn.private[:pow_mailer_layout]}]`")
 
         %{conn | private: Map.put(conn.private, :pow_mailer_layouts, _: conn.private[:pow_mailer_layout])}
 


### PR DESCRIPTION
Makes it clearer how to migrate based on #727.