### PR TITLE
Allow updating via custom context

### DIFF
--- a/lib/extensions/email_confirmation/ecto/context.ex
+++ b/lib/extensions/email_confirmation/ecto/context.ex
@@ -37,7 +37,7 @@ defmodule PowEmailConfirmation.Ecto.Context do
   def confirm_email(%user_mod{} = user, params, config) do
     user
     |> user_mod.confirm_email_changeset(params)
-    |> Context.do_update(config)
+    |> Operations.do_update(config)
   end
 
   # TODO: Remove by 1.1.0

--- a/lib/extensions/invitation/ecto/context.ex
+++ b/lib/extensions/invitation/ecto/context.ex
@@ -28,7 +28,7 @@ defmodule PowInvitation.Ecto.Context do
   def update(%user_mod{} = user, params, config) do
     user
     |> user_mod.accept_invitation_changeset(params)
-    |> Context.do_update(config)
+    |> Operations.do_update(config)
   end
 
   @doc """

--- a/lib/extensions/reset_password/ecto/context.ex
+++ b/lib/extensions/reset_password/ecto/context.ex
@@ -6,11 +6,12 @@ defmodule PowResetPassword.Ecto.Context do
   @spec get_by_email(binary(), Config.t()) :: Context.user() | nil
   def get_by_email(email, config), do: Operations.get_by([email: email], config)
 
-  @spec update_password(Context.user(), map(), Config.t()) :: {:ok, Context.user()} | {:error, Context.changeset()}
+  @spec update_password(Context.user(), map(), Config.t()) ::
+          {:ok, Context.user()} | {:error, Context.changeset()}
   def update_password(%user_mod{} = user, params, config) do
     user
     |> user_mod.reset_password_changeset(params)
-    |> Context.do_update(config)
+    |> Operations.do_update(config)
   end
 
   # TODO: Remove by 1.1.0

--- a/lib/pow/operations.ex
+++ b/lib/pow/operations.ex
@@ -58,7 +58,7 @@ defmodule Pow.Operations do
       module  -> module.create(params)
     end
   end
-
+  
   @doc """
   Update an existing user.
 
@@ -70,6 +70,20 @@ defmodule Pow.Operations do
     case context_module(config) do
       Context -> Context.update(user, params, config)
       module  -> module.update(user, params)
+    end
+  end
+  
+  @doc """
+  Update the database given a changeset.
+
+  This calls `Pow.Ecto.Context.do_update/2` or `do_update/1` on a custom context
+  module.
+  """
+  @spec do_update(Context.changeset(), Config.t()) :: {:ok, map()} | {:error, map()}
+  def do_update(changeset, config) do
+    case context_module(config) do
+      Context -> Context.do_update(changeset, config)
+      module  -> module.do_update(changeset)
     end
   end
 


### PR DESCRIPTION
Right now all of the `do_update` calls go directly to the Pow.Ecto.Context instead of the users specified module, this was preventing me from updating (Clickhouse needs some special things for updates). 

Closes #732 