### PR TITLE
Replace deprecated `Module.eval_quoted/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.39 (TBA)
+
+### Bug fixes
+
+* [`Pow.Extension.Ecto.Schema`] Fixed deprecation warning in Elixir 1.18
+
 ## v1.0.38 (2024-04-11)
 
 ### Bug fixes

--- a/lib/pow/extension/ecto/schema.ex
+++ b/lib/pow/extension/ecto/schema.ex
@@ -44,7 +44,7 @@ defmodule Pow.Extension.Ecto.Schema do
     quote do
       @pow_extension_config Config.merge(@pow_config, unquote(config))
 
-      Module.eval_quoted(__MODULE__, unquote(__MODULE__).__use_extensions__(@pow_extension_config))
+      Code.eval_quoted(unquote(__MODULE__).__use_extensions__(@pow_extension_config), [], module: __MODULE__)
 
       unquote(__MODULE__).__register_extension_fields__()
       unquote(__MODULE__).__register_extension_assocs__()


### PR DESCRIPTION
This PR intends to handle the warnings introduced in Elixir 1.18 related to the deprecation of `Module.eval_quoted/2`, by replacing the only occurrence with [Code.eval_quoted](https://hexdocs.pm/elixir/Code.html#eval_quoted/3).

closes #734 